### PR TITLE
Enforce script injection in alphabetical order

### DIFF
--- a/build.py
+++ b/build.py
@@ -207,6 +207,7 @@ def inject_scripts(input=None):
     scripts = []
 
     for dirname, dirnames, filenames in os.walk(globals()['THEME_DIR'] + "/js"):
+        filenames.sort()
         for filename in filenames:
             if filename.split('.')[-1] == 'js':
                 path = os.path.join(dirname, filename)


### PR DESCRIPTION
Python's `os.walk` doesn't guarantee that files will be returned
in alpha order (and from my experience, files aren't alphabetical
on Ubuntu 12.10 with default python).  This leads to unsatisfied
dependencies in the compiled JS (and a broken page).  Fix here
is to enforce injection in alphabetical order.
