### PR TITLE
Support genders other than Male

### DIFF
--- a/themes/official/js/05-bbclear.js
+++ b/themes/official/js/05-bbclear.js
@@ -209,8 +209,12 @@ var filters = {
     },
 
     gender_pronoun: function(input, possessive, absolute){
+        // sanitize input
+        input = input.toLowerCase();
         if(input == "female"){
             return possessive ? (absolute ? "hers" : "her") : "she";
+        }else if(input == "other"){
+            return possessive ? (absolute ? "theirs" : "their") : "they";
         }else{
             return possessive ? "his" : "he";
         }

--- a/themes/official/template.html
+++ b/themes/official/template.html
@@ -33,11 +33,13 @@
                 <p class="narrative">
                     <span class="general">
                         <strong>{{demographics.name|display_name}}</strong> is a {% if demographics.dob %}<strong>{{demographics.dob|age}}</strong> year old{% endif %}
-                        <strong>{% if demographics.race %}{{demographics.race}} {% endif %}{% if demographics.marital_status %}{{demographics.marital_status|lower}} {% endif %}{{demographics.gender|lower}}</strong>
+                        <strong>{% if demographics.race %}{{demographics.race}}{% endif %}
+                            {% if demographics.marital_status %}{{demographics.marital_status|lower}} {% endif %}
+                            {{demographics.gender|lower}}{% if demographics.gender == "Other" %}/non-binary{% endif %}</strong>
                         {% if demographics.religion or demographics.language %}who {% if demographics.religion %}is <strong>{{demographics.religion}}</strong>{% if demographics.language %} and {% endif %}{% endif %}{% if demographics.language %}speaks <strong>{{demographics.language|isolanguage|title}}</strong>{% endif %}{% endif %}.
                     </span>
                     <span class="allergies">
-                        {{demographics.gender|gender_pronoun|title}} has <strong class="{{allergies|max_severity}}">{{allergies|max_severity}} allergies</strong>.
+                        {{demographics.gender|gender_pronoun|title}}  {% if demographics.gender  == "Other" %} have {{gender_pronoun}} {% else %} has {% endif %} <strong class="{{allergies|max_severity}}">{{allergies|max_severity}} allergies</strong>.
                     </span>
                     <span class="yearReview">
                         In the past year, {{demographics.gender|gender_pronoun}}
@@ -47,7 +49,8 @@
                             {% else %}
                                 had <strong>medical encounters</strong>
                             {% endif %}
-                        </span> and has <span id="yearReviewMedications">
+                        </span> and {% if demographics.gender  == "Other" %} have {{gender_pronoun}} {% else %} has {% endif %}
+<span id="yearReviewMedications">
                             {% if medications|since_days(365)|strict_length == 0 %}
                                 not had any medications prescribed.
                             {% else %}


### PR DESCRIPTION
## Issues addressed:
- The [if statement for gender_pronoun](https://github.com/blue-button/bbClear/compare/master...rubinovitz:master#diff-8e743768fa6b6ad022e9d7a9dadc9036L212) would check for "Female" input using a conditional for "female". I decided to sanitize the input to lower case because I don't trust the input, but we can also check for "Female" instead.
- bbClear did not account for the [other](https://www.hl7.org/fhir/valueset-administrative-gender.html) gender marker, as per HL7. I added it to the conditionals in 05-bbclear.js and added conditionals in template.html to change "has" to "have" in the case of "Other". I also render their gender as other/nonbinary vs just other.
### Example of Female

<img width="827" alt="screen shot 2015-11-06 at 12 43 56 pm" src="https://cloud.githubusercontent.com/assets/1807895/11004071/1624b520-8484-11e5-83cd-d84973ad1426.png">
### Example of Other

<img width="783" alt="screen shot 2015-11-06 at 12 30 16 pm" src="https://cloud.githubusercontent.com/assets/1807895/11003979/ae1b1ba4-8483-11e5-8182-5d7099f7b4fe.png">
## To do:
- The repo does not contain test XML for Female or Other gender categories.
## Reference:
- [Electronic medical records and the transgender patient: recommendations from the World Professional Association for Transgender Health EMR Working Group](http://www.ncbi.nlm.nih.gov/pmc/articles/PMC3721165/#bx1)
- [Value Set http://hl7.org/fhir/ValueSet/administrative-gender](https://www.hl7.org/fhir/valueset-administrative-gender.html)

Also unsure if I treated the Other category in the best possible manner. Open to suggestions from people with more experience working on it.
